### PR TITLE
Retina ColoredCircleSprite, Mac App Compatibility

### DIFF
--- a/Classes/ColoredCircleSprite.m
+++ b/Classes/ColoredCircleSprite.m
@@ -73,8 +73,8 @@
 	
 	for(int i=0; i<numberOfSegments; i++)
 	{
-		float j = radius_ * cosf(theta) + position_.x;
-		float k = radius_ * sinf(theta) + position_.y;
+		float j = radius_ * [[CCDirector sharedDirector] contentScaleFactor] * cosf(theta) + position_.x;
+		float k = radius_ * [[CCDirector sharedDirector] contentScaleFactor] * sinf(theta) + position_.y;
 		
 		circleVertices_[i*2]	= j;
 		circleVertices_[i*2+1]	= k;

--- a/Classes/SneakyJoystick.h
+++ b/Classes/SneakyJoystick.h
@@ -13,7 +13,12 @@
 
 #import "cocos2d.h"
 
+#ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
 @interface SneakyJoystick : CCNode <CCTargetedTouchDelegate> {
+#elif defined(__MAC_OS_X_VERSION_MAX_ALLOWED)
+@interface SneakyJoystick : CCNode {
+#endif
+	
 	CGPoint stickPosition;
 	float degrees;
 	CGPoint velocity;

--- a/Classes/SneakyJoystick.m
+++ b/Classes/SneakyJoystick.m
@@ -66,12 +66,18 @@ deadRadius;
 
 - (void) onEnterTransitionDidFinish
 {
+#ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
 	[[CCTouchDispatcher sharedDispatcher] addTargetedDelegate:self priority:1 swallowsTouches:YES];
+#elif defined(__MAC_OS_X_VERSION_MAX_ALLOWED)
+#endif
 }
 
 - (void) onExit
 {
+#ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
 	[[CCTouchDispatcher sharedDispatcher] removeDelegate:self];
+#elif defined(__MAC_OS_X_VERSION_MAX_ALLOWED)
+#endif
 }
 
 -(void)updateVelocity:(CGPoint)point
@@ -145,6 +151,7 @@ deadRadius;
 
 #pragma mark Touch Delegate
 
+#ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
 - (BOOL)ccTouchBegan:(UITouch *)touch withEvent:(UIEvent *)event
 {
 	CGPoint location = [[CCDirector sharedDirector] convertToGL:[touch locationInView:[touch view]]];
@@ -184,5 +191,7 @@ deadRadius;
 {
 	[self ccTouchEnded:touch withEvent:event];
 }
+#elif defined(__MAC_OS_X_VERSION_MAX_ALLOWED)
+#endif
 
 @end


### PR DESCRIPTION
I've been using SneakyJoystick in code that is being compiled both for Mac and iOS, so I had to ifdef out touch delegate-related code. I thought this might be useful for others.

As well, I made the ColoredCircleSprite compensate for the CCDirector's content scale factor to allow it to work in retina mode.
