### PR TITLE
Retina ColoredCircleSprite mac-compatible

### DIFF
--- a/Classes/ColoredCircleSprite.m
+++ b/Classes/ColoredCircleSprite.m
@@ -73,8 +73,13 @@
 	
 	for(int i=0; i<numberOfSegments; i++)
 	{
+#ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
 		float j = radius_ * [[CCDirector sharedDirector] contentScaleFactor] * cosf(theta) + position_.x;
 		float k = radius_ * [[CCDirector sharedDirector] contentScaleFactor] * sinf(theta) + position_.y;
+#elif defined(__MAC_OS_X_VERSION_MAX_ALLOWED)
+		float j = radius_ * cosf(theta) + position_.x;
+		float k = radius_ * sinf(theta) + position_.y;
+#endif				
 		
 		circleVertices_[i*2]	= j;
 		circleVertices_[i*2+1]	= k;


### PR DESCRIPTION
Quick follow-up: I made the ColoredCircleSprite NOT compensate for retina mode when compiled in a mac app.
